### PR TITLE
Debug react minified error 310 in TasksPanel

### DIFF
--- a/src/components/TasksPanel.tsx
+++ b/src/components/TasksPanel.tsx
@@ -25,6 +25,15 @@ const TasksPanel: React.FC = () => {
   const { completedTasks, loading: completionLoading, error: completionError } = useUserTaskCompletion(user?.userId || null);
   const [completingTask, setCompletingTask] = useState<string | null>(null);
 
+  // Move all useMemo hooks to top level to avoid hook order violations
+  const activeTasks = useMemo(() => tasks.filter(task => task.active), [tasks]);
+  const dailyTasks = useMemo(() => activeTasks.filter(t => t.type === 'daily'), [activeTasks]);
+  const weeklyTasks = useMemo(() => activeTasks.filter(t => t.type === 'weekly'), [activeTasks]);
+  const specialTasks = useMemo(() => activeTasks.filter(t => t.type === 'special'), [activeTasks]);
+  const socialTasks = useMemo(() => activeTasks.filter(t => ['youtube', 'channel_join', 'group_join', 'link'].includes(t.type)), [activeTasks]);
+  const completedCount = useMemo(() => activeTasks.filter(t => completedTasks.includes(t.id)).length, [activeTasks, completedTasks]);
+  const remainingCount = useMemo(() => activeTasks.length - completedCount, [activeTasks, completedCount]);
+
   // FIX: Add error handling and loading state for blank screen issue
   if (tasksLoading || completionLoading) {
     return (
@@ -251,16 +260,6 @@ const TasksPanel: React.FC = () => {
       </motion.div>
     );
   };
-
-  // Move all useMemo hooks to top level to avoid hook order violations
-  const activeTasks = useMemo(() => tasks.filter(task => task.active), [tasks]);
-  const dailyTasks = useMemo(() => activeTasks.filter(t => t.type === 'daily'), [activeTasks]);
-  const weeklyTasks = useMemo(() => activeTasks.filter(t => t.type === 'weekly'), [activeTasks]);
-  const specialTasks = useMemo(() => activeTasks.filter(t => t.type === 'special'), [activeTasks]);
-  const socialTasks = useMemo(() => activeTasks.filter(t => ['youtube', 'channel_join', 'group_join', 'link'].includes(t.type)), [activeTasks]);
-
-  const completedCount = useMemo(() => activeTasks.filter(t => completedTasks.includes(t.id)).length, [activeTasks, completedTasks]);
-  const remainingCount = useMemo(() => activeTasks.length - completedCount, [activeTasks, completedCount]);
 
   // Handle early returns AFTER all hooks
   if (!user) return null;


### PR DESCRIPTION
Move `useMemo` hooks to the top of `TasksPanel.tsx` to resolve React error #310.

The `useMemo` hooks were previously called after conditional early returns (for loading, error, and user states), violating React's Rules of Hooks and causing error #310. Moving them to the top ensures they are always called in the same order on every render.

---
<a href="https://cursor.com/background-agent?bcId=bc-573ac375-bd36-45b7-9375-e89bdc9383bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-573ac375-bd36-45b7-9375-e89bdc9383bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

